### PR TITLE
Solve urllib Forbidden error

### DIFF
--- a/generate_graph.py
+++ b/generate_graph.py
@@ -1,5 +1,5 @@
 import base64
-from urllib.request import urlretrieve
+import urllib.request
 
 INPUT_FILE = "graph.md"
 
@@ -10,5 +10,17 @@ with open(INPUT_FILE, "r") as graph_file:
         g_code.replace("\n", "\\n").encode("utf-8")
     )
     link = "https://mermaid.ink/img/%s" % base64_graph.decode("utf-8")
-    print(link)
-    urlretrieve(link, "output.jpeg")
+    print("Image_link: " + link)
+    hdrs = {
+        "User-Agent": "Mozilla / 5.0 (X11 Linux x86_64) AppleWebKit / 537.36 (KHTML, like Gecko) Chrome / 52.0.2743.116 Safari / 537.36"
+    }
+    opener = urllib.request.build_opener()
+    opener.addheaders = [
+        (
+            "User-Agent",
+            "Mozilla / 5.0 (X11 Linux x86_64) AppleWebKit / 537.36 (KHTML, like Gecko) Chrome / 52.0.2743.116 Safari 537.36",
+        )
+    ]
+    urllib.request.install_opener(opener)
+    urllib.request.urlretrieve(link, "output.jpeg")
+    print("\nFind downloaded image output.jpeg in current directory")


### PR DESCRIPTION
Solve error:
Traceback (most recent call last):
  File "generate_graph.py", line 14, in <module>
    urlretrieve(link, "output.jpeg")
  File "/usr/lib/python3.6/urllib/request.py", line 248, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
  File "/usr/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/lib/python3.6/urllib/request.py", line 532, in open
    response = meth(req, response)
  File "/usr/lib/python3.6/urllib/request.py", line 642, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib/python3.6/urllib/request.py", line 570, in error
    return self._call_chain(*args)
  File "/usr/lib/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib/python3.6/urllib/request.py", line 650, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden